### PR TITLE
Modify speak endpoint to return wav by query param

### DIFF
--- a/tts-service.py
+++ b/tts-service.py
@@ -43,7 +43,7 @@ def voice_api():
     token = request.args.get('token')
     file_type = request.args.get('type')
 
-    if file_type not in ("wav", "mp3", None):
+    if file_type not in ("wav", "x-wav", "mp3", None):
         return ("Bad Request", 400)
 
     if token is None or getMD5(text) != token.lower():
@@ -72,8 +72,8 @@ def voice_api():
         p = subprocess.Popen(cmd, shell=True, stdout=subprocess.PIPE)
         p.wait()
 
-        if (file_type == "wav"):
-            return send_file(wave_file.name, mimetype="audio/x-wav",
+        if file_type in ("wav", "x-wav"):
+            return send_file(wave_file.name, mimetype="audio/" + str(file_type),
                              as_attachment=False, attachment_filename=wave_file.name)
 
         cmd = '{0} {1} {2}'.\

--- a/tts-service.py
+++ b/tts-service.py
@@ -41,6 +41,10 @@ def getMD5(text):
 def voice_api():
     text = request.args.get('text')
     token = request.args.get('token')
+    file_type = request.args.get('type')
+
+    if file_type not in ("wav", "mp3", None):
+        return ("Bad Request", 400)
 
     if token is None or getMD5(text) != token.lower():
         return ("Forbidden", 403)
@@ -67,6 +71,10 @@ def voice_api():
               format(txt2wave, wave_file.name, encoded_file.name)
         p = subprocess.Popen(cmd, shell=True, stdout=subprocess.PIPE)
         p.wait()
+
+        if (file_type == "wav"):
+            return send_file(wave_file.name, mimetype="audio/wav",
+                             as_attachment=False, attachment_filename=wave_file.name)
 
         cmd = '{0} {1} {2}'.\
               format(lame, wave_file.name, mp3_file.name)

--- a/tts-service.py
+++ b/tts-service.py
@@ -73,7 +73,7 @@ def voice_api():
         p.wait()
 
         if (file_type == "wav"):
-            return send_file(wave_file.name, mimetype="audio/wav",
+            return send_file(wave_file.name, mimetype="audio/x-wav",
                              as_attachment=False, attachment_filename=wave_file.name)
 
         cmd = '{0} {1} {2}'.\


### PR DESCRIPTION
Added 'type' query param to speak endpoint, nothing changes in usage, but if '&type=wav' is passed to url, lame is skipped and wav returned.
Simple change to be able to play it with "_aplay **file.wav**_" or curl-aplay "_curl '**url**' | aplay_"